### PR TITLE
feat: Add tags

### DIFF
--- a/doc/tags
+++ b/doc/tags
@@ -1,0 +1,54 @@
+norg-tutorial--norg-tutorial	../norg_tutorial.norg	/* Norg Tutorial
+norg-tutorial--useful-videos	../norg_tutorial.norg	/** Useful Videos
+norg-tutorial--how-to-get-started	../norg_tutorial.norg	/* How to Get Started
+norg-tutorial--installation-guide	../norg_tutorial.norg	/** Installation Guide
+norg-tutorial--kickstart-config	../norg_tutorial.norg	/** Kickstart Config
+norg-tutorial--core.dirman	../norg_tutorial.norg	/*** `core.dirman`
+norg-tutorial--how-to-write-your-notes	../norg_tutorial.norg	/* How to Write Your Notes
+norg-tutorial--basics-of-modules	../norg_tutorial.norg	/** Basics of Modules
+norg-tutorial--how-to-write-notes	../norg_tutorial.norg	/** How to Write Notes
+norg-tutorial--heading-1	../norg_tutorial.norg	/* Heading 1
+norg-tutorial--heading-2	../norg_tutorial.norg	/** Heading 2
+norg-tutorial--links	../norg_tutorial.norg	/* Links
+norg-tutorial--links-examples	../norg_tutorial.norg	/** Links Examples
+norg-tutorial--attached-modifiers	../norg_tutorial.norg	/* Attached Modifiers
+norg-tutorial--modules	../norg_tutorial.norg	/* Modules
+norg-tutorial--notes-for-important-modules	../norg_tutorial.norg	/** Notes for Important Modules
+norg-tutorial--core.journal	../norg_tutorial.norg	/*** `core.journal`
+norg-tutorial--core.keybinds	../norg_tutorial.norg	/*** `core.keybinds`
+norg-tutorial--core.export	../norg_tutorial.norg	/*** `core.export`
+norg-tutorial--core.summary	../norg_tutorial.norg	/*** `core.summary`
+norg-tutorial--core.tangle	../norg_tutorial.norg	/*** `core.tangle`
+norg-tutorial--tangle-each-code-block.	../norg_tutorial.norg	/**** Tangle each code block.
+norg-tutorial--tangle-entire-document.	../norg_tutorial.norg	/**** Tangle entire document.
+norg-tutorial--automatically-tangle-current-file-on-save-using-autocmd.	../norg_tutorial.norg	/**** Automatically tangle current file on save using `autocmd`.
+norg-tutorial--core.looking-glass	../norg_tutorial.norg	/*** `core.looking-glass`
+norg-tutorial--export-/-import	../norg_tutorial.norg	/** Export / Import
+norg-tutorial--builtin-export-module	../norg_tutorial.norg	/*** Builtin Export Module
+norg-tutorial--export:-norganic-+-pandoc-+-norg.jl	../norg_tutorial.norg	/*** Export: `norganic + pandoc + Norg.jl`
+norg-tutorial--export:-norg-pandoc	../norg_tutorial.norg	/*** Export: `norg-pandoc`
+norg-tutorial--import:-pandoc-+-minorg	../norg_tutorial.norg	/*** Import: `pandoc + minorg`
+norg-tutorial--future:-tree-sitter-v3-parser	../norg_tutorial.norg	/*** Future: tree-sitter v3 parser
+norg-tutorial--image-support	../norg_tutorial.norg	/** Image Support
+norg-tutorial--visualization	../norg_tutorial.norg	/*** Visualization
+norg-tutorial--table-syntax	../norg_tutorial.norg	/** Table Syntax
+norg-tutorial--markdown-wrapper	../norg_tutorial.norg	/*** Markdown Wrapper
+norg-tutorial--rich-table-format	../norg_tutorial.norg	/*** Rich Table Format
+norg-tutorial--alignments	../norg_tutorial.norg	/**** Alignments
+norg-tutorial--table-format-examples	../norg_tutorial.norg	/*** Table Format Examples
+norg-tutorial--macros	../norg_tutorial.norg	/** Macros
+norg-tutorial--attached-modifier-extensions-(wip)	../norg_tutorial.norg	/*** Attached Modifier Extensions (WIP)
+norg-tutorial--detached-modifier-extensions-(wip)	../norg_tutorial.norg	/*** Detached Modifier Extensions (WIP)
+norg-tutorial--your-own-module	../norg_tutorial.norg	/** Your Own Module
+norg-tutorial--explore-more-norg	../norg_tutorial.norg	/* Explore More Norg
+norg-tutorial--github-tags	../norg_tutorial.norg	/** GitHub Tags
+norg-tutorial--discord	../norg_tutorial.norg	/** Discord
+norg-tutorial--tips	../norg_tutorial.norg	/* Tips
+norg-tutorial--embed-images	../norg_tutorial.norg	/** Embed Images
+norg-tutorial--old:-discussions	../norg_tutorial.norg	/*** OLD: Discussions
+norg-tutorial--old:-workaround	../norg_tutorial.norg	/*** OLD: Workaround
+norg-tutorial--sync-with-git	../norg_tutorial.norg	/** Sync with Git
+norg-tutorial--nextcloud	../norg_tutorial.norg	/*** Nextcloud
+norg-tutorial--after-logging-in	../norg_tutorial.norg	/**** After Logging In
+norg-tutorial--on-your-phone	../norg_tutorial.norg	/**** On Your Phone
+norg-tutorial--notes	../norg_tutorial.norg	/**** Notes

--- a/docgen.py
+++ b/docgen.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+# TODO: gendoc CI on push?
+import re
+
+def strip_head(s):
+    return s.strip().lower().replace("`", "").replace("*", "").replace(" ", "-")
+
+with open('./norg_tutorial.norg') as file:
+    lines = file.read().strip()
+
+headings = re.findall(r"^\s*(\*+ [a-zA-Z0-9_\-\.\ :`\/\+\(\)]+)", lines, re.MULTILINE)
+
+res = ""
+for head in headings:
+    res += f"norg-tutorial-{strip_head(head)}\t../norg_tutorial.norg\t/{head}\n"
+
+
+with open('./doc/tags', 'w') as f:
+    f.write(res)


### PR DESCRIPTION
Now, we can install this repository as a plugin via a package manager normally.
`:h norg-tutorial` and all other headings/subheadings are available in the help menu.

docgen.py is used to generate the docs. Its just for the dev and/or the github workflow action so the tags can be automatically generated when the `norg_tutorial.norg` file is changed.